### PR TITLE
Style- fixes

### DIFF
--- a/style.css
+++ b/style.css
@@ -2810,7 +2810,7 @@ p > video {
 	}
 
 	.site-header {
-		padding: 0 6.5% 0 3.2%;
+		padding: 0 6.5% 0 3.7%;
 	}
 
 	.site-branding {
@@ -3014,7 +3014,7 @@ p > video {
 	}
 
 	.archive.post-type-archive-newsletter .page-header {
-		margin-left: 7.4%;
+		margin-left: 2.5%;
 	}
 	.archive.post-type-archive-newsletter_article .page-header {
 		margin-left: 7.5%;
@@ -3470,7 +3470,7 @@ p > video {
 	}
 
 	.archive.post-type-archive-newsletter .page-header {
-		margin-left: 3.9%;
+		margin-left: 3%;
 	}
 	.archive.post-type-archive-newsletter_article .page-header {
 		margin-left: 3%;

--- a/style.css
+++ b/style.css
@@ -2618,11 +2618,11 @@ p > video {
 }
 
 .wp-caption .wp-caption-text {
-    color: #1a1a1a;
-    font-size: 16px;
-    font-style: italic;
-    line-height: 1.6153846154;
-    padding-top: 0.5384615385em;
+	color: #1a1a1a;
+	font-size: 16px;
+	font-style: italic;
+	line-height: 1.6153846154;
+	padding-top: 0.5384615385em;
 }
 
 
@@ -2956,7 +2956,7 @@ p > video {
 	}
 
 	blockquote {
-    	font-size: 25px;
+		font-size: 25px;
 	}
 
 	.entry-content blockquote blockquote:not(.alignleft):not(.alignright),
@@ -3223,8 +3223,8 @@ p > video {
 	}
 
 	.entry-content .wp-caption.alignnone {
-  	  	margin-right: -9%;
-    	margin-left: -9%;
+		margin-right: -9%;
+		margin-left: -9%;
 	}
 
 	.entry-content .wp-caption.alignleft {
@@ -3738,7 +3738,7 @@ p > video {
 @media screen and (min-width: 75em) {
 
 	.site-header {
-	padding: 1.5em 4.5455% 0 4.5455%;
+		padding: 1.5em 4.5455% 0 4.5455%;
 	}
 
 	.home.blog article.type-newsletter_article,

--- a/style.css
+++ b/style.css
@@ -1541,7 +1541,7 @@ blockquote:after,
  */
 
 .site-header {
-	padding: 2em 7.6923%;
+	padding: 1em 7.6923% 0;
 }
 
 .site-header-main {
@@ -1599,7 +1599,7 @@ blockquote:after,
 
 /* @todo make temporary hack to get the title we want more general */
 .site-title {
-	width: 6.5em;
+	width: 5.5em;
 	line-height: 0.8 !important;
 	padding-bottom: 0.1ex; /* don't clip font because of line-height */
 }
@@ -2810,7 +2810,7 @@ p > video {
 	}
 
 	.site-header {
-		padding: 1em 7.6923%;
+		padding: 0 4.5455%;
 	}
 
 	.site-branding {
@@ -3032,8 +3032,7 @@ p > video {
 
 @media screen and (min-width: 56.875em) {
 	.site-header {
-		padding-right: 4.5455%;
-		padding-left: 4.5455%;
+		padding: 0 4.5455% 0 4.5455%;
 	}
 
 	.site-header-main {
@@ -3490,7 +3489,7 @@ p > video {
 	}
 
 	.site-header {
-		padding: 1.5em 4.5455% 0 4.5455%;
+		padding: 1.5em 5.4% 0;
 	}
 
 	.site-branding,
@@ -3700,6 +3699,10 @@ p > video {
  */
 
 @media screen and (min-width: 75em) {
+
+	.site-header {
+	padding: 1.5em 4.5455% 0 4.5455%;
+	}
 
 	.home.blog article.type-newsletter_article,
 	.archive article.type-newsletter,

--- a/style.css
+++ b/style.css
@@ -1683,7 +1683,7 @@ blockquote:after,
 .entry-title,
 .page-title {
 	font-family: "Playfair Display", Georgia, serif;
-	font-size: 50px;
+	font-size: 40px;
 	font-weight: 700;
 	line-height: 1.25;
 }
@@ -2189,6 +2189,7 @@ body.search-no-results .page-header {
 	 * TODO custom thumbnail size for type / crop in UI on upload. */
 	height: 300px;
 	overflow: hidden;
+	margin-top: -0.5em;
 }
 
 .blog .entry-title {
@@ -2212,21 +2213,18 @@ body.search-no-results .page-header {
 	/* @todo use clamp.js for ellipsis */
 }
 
-/*
-.type-newsletter .entry-title,
-.type-newsletter_article .entry-title {
+.type-newsletter .entry-title {
 	font-family: Lora, Georgia, serif;
-	font-style: italic;
-	font-size: 22px;
+	font-size: 25px;
 	line-height: 1.1;
 	margin-bottom: 0.2em;
 }
-*/
 
 .type-newsletter .entry-subtitle,
 .type-newsletter_article .entry-subtitle {
 	line-height: 1.5;
 	font-size: 20px;
+	font-style: italic;
 	white-space: nowrap;
 	overflow: hidden;
 	text-overflow: ellipsis;
@@ -3419,8 +3417,8 @@ p > video {
 	.archive article.type-newsletter .entry-summary,
 	.archive article.type-newsletter .entry-footer,
 	.archive article.type-newsletter .post-thumbnail {
-		margin-left: 8%;
-		margin-right: 8%;
+		margin-left: 6%;
+		margin-right: 6%;
 	}
 
 	.home.blog article.type-newsletter_article .entry-header,
@@ -3498,11 +3496,10 @@ p > video {
 
 	.page-header,
 	.entry-header {
-		margin-bottom: 2em;
+		margin-bottom: 1.5em;
 	}
 
 	.page-title, .entry-title {
-		font-size: 40px;
 		line-height: 1.225;
 	}
 
@@ -3794,7 +3791,7 @@ p > video {
 	}
 
 	.archive.post-type-archive-newsletter .page-header {
-		margin-left: 2.75%;
+		margin-left: 2%;
 	}
 	.archive.post-type-archive-newsletter_article .page-header {
 		margin-left: 2%;

--- a/style.css
+++ b/style.css
@@ -1529,6 +1529,7 @@ blockquote:after,
 
 .site-main {
 	margin-bottom: 3.5em;
+	border-top: 1px solid #ccc;
 }
 
 .site-main > :last-child {
@@ -1688,6 +1689,7 @@ blockquote:after,
 .page-header,
 .entry-header {
 	margin-bottom: 1.5em;
+	padding-top: 1.5em;
 }
 
 .entry-title,
@@ -2184,7 +2186,6 @@ body.search-no-results .page-header {
 	margin-bottom: 2em;
 	padding-top: 1.5em;
 	border-bottom: 1px solid #ccc;
-	border-top: 1px solid #ccc;
 }
 
 .home.blog article.type-newsletter,

--- a/style.css
+++ b/style.css
@@ -2784,6 +2784,7 @@ p > video {
 	}
 
 	.site-branding {
+		max-width: 28%;
 		margin-top: 1.3125em;
 		margin-bottom: 1.3125em;
 		margin-left: 1.3em;

--- a/style.css
+++ b/style.css
@@ -902,6 +902,7 @@ a:active {
 .social-navigation ul {
 	list-style: none;
 	margin: 0 0 -0.4375em;
+	padding-left: 0;
 }
 
 .social-navigation li {
@@ -2937,7 +2938,11 @@ p > video {
 	.entry-content blockquote:not(.alignleft):not(.alignright),
 	.entry-summary blockquote,
 	.comment-content blockquote {
-		margin: 1em 3em 1em 2em;
+		margin: 1em 0em 1em 2em;
+	}
+
+	blockquote {
+    	font-size: 25px;
 	}
 
 	.entry-content blockquote blockquote:not(.alignleft):not(.alignright),

--- a/style.css
+++ b/style.css
@@ -2201,6 +2201,15 @@ body.search-no-results .page-header {
 	margin-bottom: 1em;
 }
 
+.home.blog article.type-newsletter_article:after {
+    content: ""; /* This is necessary for the pseudo element to work. */ 
+    display: block; /* This will put the pseudo element on its own line. */
+    margin: 0; /* This will center the border. */
+    width: 25%;
+    padding-top: 2.5em;
+    border-bottom: 1px solid #ccc;
+}
+
 .newsletter-post-thumbnail-container {
 	/* Fixed height to keep floats aligned.
 	 * TODO custom thumbnail size for type / crop in UI on upload. */

--- a/style.css
+++ b/style.css
@@ -3481,11 +3481,7 @@ p > video {
 	.archive article.type-newsletter .entry-content,
 	.archive article.type-newsletter .entry-summary,
 	.archive article.type-newsletter .entry-footer,
-	.archive article.type-newsletter .post-thumbnail {
-		margin-left: 6%;
-		margin-right: 6%;
-	}
-
+	.archive article.type-newsletter .post-thumbnail,
 	.home.blog article.type-newsletter_article .entry-header,
 	.home.blog article.type-newsletter_article .entry-content,
 	.home.blog article.type-newsletter_article .entry-summary,

--- a/style.css
+++ b/style.css
@@ -2603,11 +2603,11 @@ p > video {
 }
 
 .wp-caption .wp-caption-text {
-	color: #686868;
-	font-size: 13px;
-	font-style: italic;
-	line-height: 1.6153846154;
-	padding-top: 0.5384615385em;
+    color: #1a1a1a;
+    font-size: 16px;
+    font-style: italic;
+    line-height: 1.6153846154;
+    padding-top: 0.5384615385em;
 }
 
 

--- a/style.css
+++ b/style.css
@@ -1529,8 +1529,11 @@ blockquote:after,
 }
 
 .site-main {
-	margin-bottom: 3.5em;
+	margin-bottom: 1em;
 	border-top: 1px solid #ccc;
+	border-bottom: 1px solid #ccc;
+	border-bottom: 1px solid #ccc;
+	padding-bottom: 3em;
 }
 
 .site-main > :last-child {
@@ -2808,7 +2811,7 @@ p > video {
 	}
 
 	.site-main {
-		margin-bottom: 5.25em;
+		margin-bottom: 1em;
 	}
 
 	.site-header {
@@ -3508,7 +3511,7 @@ p > video {
 
 @media screen and (min-width: 61.5625em) {
 	.site-main {
-		margin-bottom: 7.0em;
+		margin-bottom: 1.5em;
 	}
 
 	.site-header {
@@ -4059,7 +4062,7 @@ p > video {
 	}
 
 	.site-main {
-		margin-bottom: 3.5em;
+		margin-bottom: 1.5em;
 	}
 
 	.entry-header,

--- a/style.css
+++ b/style.css
@@ -2810,7 +2810,7 @@ p > video {
 	}
 
 	.site-header {
-		padding: 0 4.5455%;
+		padding: 0 6.5% 0 3.2%;
 	}
 
 	.site-branding {
@@ -2855,6 +2855,10 @@ p > video {
 		margin: 1.3125em 0;
 	}
 
+	.site-content {
+		padding: 0 4.5455%;
+	}
+
 	.pagination {
 		margin: 0 23.0769% 4.421052632em 7.6923%
 	}
@@ -2892,8 +2896,8 @@ p > video {
 	.page-header,
 	.page-content,
 	.content-bottom-widgets {
-		margin-right: 15%;
-		margin-left: 15%;
+		margin-right: 5%;
+		margin-left: 5%;
 	}
 
 	/*.entry-title {

--- a/style.css
+++ b/style.css
@@ -2215,7 +2215,6 @@ body.search-no-results .page-header {
 	 * TODO custom thumbnail size for type / crop in UI on upload. */
 	height: 300px;
 	overflow: hidden;
-	margin-top: -0.5em;
 }
 
 .blog .entry-title {
@@ -2232,12 +2231,11 @@ body.search-no-results .page-header {
 
 .home.blog article.type-newsletter .entry-header,
 .home.blog article.type-newsletter_article .entry-header,
-.archive article.type-newsletter .entry-header,
 .archive article.type-newsletter_article .entry-header {
 	margin-bottom: 3.25ex; /* make gap between title and text a bit smaller */
 }
 
-
+.archive article.type-newsletter .entry-header,
 .home.blog article.type-newsletter .entry-summary,
 .home.blog article.type-newsletter_article .entry-summary,
 .archive article.type-newsletter .entry-summary,

--- a/style.css
+++ b/style.css
@@ -790,6 +790,7 @@ a:active {
 .site-header-menu.toggled-on,
 .no-js .site-header-menu {
 	display: block;
+	margin: 0.875em 0 0.875em 50%;
 }
 
 .main-navigation {
@@ -840,7 +841,8 @@ a:active {
 }
 
 .main-navigation .primary-menu {
-	border-bottom: 1px solid #d1d1d1;
+	padding-left: 0em;
+	border-bottom: 0px solid #d1d1d1;
 }
 
 .main-navigation .menu-item-has-children > a {

--- a/style.css
+++ b/style.css
@@ -2198,16 +2198,16 @@ body.search-no-results .page-header {
 .home.blog article.type-newsletter_article,
 .archive article.type-newsletter,
 .archive article.type-newsletter_article {
-	margin-bottom: 1em;
+	margin-bottom: 0em;
 }
 
 .home.blog article.type-newsletter_article:after {
-    content: ""; /* This is necessary for the pseudo element to work. */ 
-    display: block; /* This will put the pseudo element on its own line. */
-    margin: 0; /* This will center the border. */
-    width: 25%;
-    padding-top: 2.5em;
-    border-bottom: 1px solid #ccc;
+	content: ""; /* This is necessary for the pseudo element to work. */ 
+	display: block; /* This will put the pseudo element on its own line. */
+	margin: 0; /* This will center the border. */
+	width: 25%;
+	padding-top: 1.5em;
+	border-bottom: 1px solid #ccc;
 }
 
 .newsletter-post-thumbnail-container {
@@ -2233,6 +2233,10 @@ body.search-no-results .page-header {
 .home.blog article.type-newsletter_article .entry-header,
 .archive article.type-newsletter_article .entry-header {
 	margin-bottom: 3.25ex; /* make gap between title and text a bit smaller */
+}
+
+.home.blog article.type-newsletter_article .entry-header {
+	padding-top: 1ex;
 }
 
 .archive article.type-newsletter .entry-header,

--- a/style.css
+++ b/style.css
@@ -3203,6 +3203,19 @@ p > video {
 		margin-left: 0;
 	}
 
+	.entry-content .wp-caption.alignnone {
+  	  	margin-right: -9%;
+    	margin-left: -9%;
+	}
+
+	.entry-content .wp-caption.alignleft {
+    	margin-left: -9%;
+	}
+
+	.entry-content .wp-caption.alignright {
+    	margin-right: -9%;
+	}
+
 	.widget {
 		font-size: 13px;
 		line-height: 1.6153846154;

--- a/style.css
+++ b/style.css
@@ -2828,7 +2828,6 @@ p > video {
 	}
 
 	.site-branding {
-		max-width: 28%;
 		margin-top: 1.3125em;
 		margin-bottom: 1.3125em;
 		margin-left: 1.3em;


### PR DESCRIPTION
Het lijstje is redelijk schoon nu. Zie commits voor toelichting. Alleen een begrenzing van de artikelen heb ik nog niet. Nu de marge beter zijn, vind ik het ook minder nodig.

- Plaatjes in artikelen netjes afmaken [G]
- Captions [G] (evt.)
- Colofon invullen met pagina 2 [G]
- Agenda [G]
- Bedelnap [G]
- Woord vooraf [G] OF redactioneel (Wat willen we.)
- Eerste responsive sprong horizontale marges kleiner [G]
- Eerste responsive sprong site titel uitlijning [G]
- Nieuwsbrieven archief
  - Koppen zelfde als voorpagina
  - Marge tekst - plaatje kleiner [G]
  - Uitlijning met site titel [G] (evt.)
- [ ] Don't clear floats with new heading on article page

Extra:
- verbeteringen toggle menu
- consequent toepassen lijnen (voorstellen)
- details

BUG REPORT: social media icons in Toggle menu., willen we dat. Het is gekoppelt nu, ik kan het niet uitzetten
